### PR TITLE
Fix issue 27

### DIFF
--- a/mei30To40/mei30To40.xsl
+++ b/mei30To40/mei30To40.xsl
@@ -1021,7 +1021,7 @@
   </xsl:template>
 
   <!-- Move physLoc/provenance inside physLoc/history -->
-  <xsl:template match="mei:physLoc" mode="copy">
+  <xsl:template match="mei:physLoc" mode="#all">
     <physLoc>
       <xsl:apply-templates select="mei:head" mode="copy"/>
       <xsl:apply-templates select="mei:repository" mode="copy"/>


### PR DESCRIPTION
Fix Issue #27 

mei30To40.xsl failed to convert MEI 3 \<physLoc\> \<provenance\> into MEI 4 \<physLoc\> \<history\> \<provenance\>.

It should have matched the template on line 1024, but failed because it was in mode bibl, instead it matched the template on line 2427.

Fix changed the mode on line 1024 to mode="#all"