### PR TITLE
tools: v5 transformation review of mei40To50.xsl

### DIFF
--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -504,7 +504,7 @@
     
     <xd:doc>
         <xd:desc>
-            <xd:p>Specify the new version of MEI</xd:p>
+            <xd:p>Update @meiversion the new version of MEI.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="@meiversion">

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -449,7 +449,11 @@
                 <xsl:attribute name=" target" select="$gitUrl"/>
             </xsl:element>
         </xsl:element>
+        <xsl:if test="$verbose">
+            <xsl:message select="'Added application element with documentation of this XSLT.'"/>
+        </xsl:if>
     </xsl:template>
+    
     <xd:doc>
         <xd:desc>
             <xd:p>Create mei:appInfo element.</xd:p>
@@ -492,6 +496,9 @@
             <xsl:element name="encodingDesc" namespace="http://www.music-encoding.org/ns/mei">
                 <xsl:call-template name="encodingDesc-insert-appInfo"/>
             </xsl:element>
+            <xsl:if test="$verbose">
+                <xsl:message select="'Added encodingDesc element to the encoding.'"/>
+            </xsl:if>
         </xsl:if>
     </xsl:template>
     

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -450,6 +450,19 @@
             </xsl:element>
         </xsl:element>
     </xsl:template>
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Create mei:appInfo element.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="encodingDesc-insert-appInfo">
+        <xsl:element name="appInfo" namespace="http://www.music-encoding.org/ns/mei">
+            <xsl:call-template name="appInfo-insert-current-application"/>
+        </xsl:element>
+        <xsl:if test="$verbose">
+            <xsl:message select="'Added appInfo element to the encoding.'"/>
+        </xsl:if>
+    </xsl:template>
     
     <xd:doc>
         <xd:desc>
@@ -460,9 +473,7 @@
         <xsl:copy>
             <xsl:apply-templates select="@*"/>
             <xsl:if test="not(mei:appInfo)">
-                <xsl:element name="appInfo" namespace="http://www.music-encoding.org/ns/mei">
-                    <xsl:call-template name="appInfo-insert-current-application"/>
-                </xsl:element>
+                <xsl:call-template name="encodingDesc-insert-appInfo"/>
             </xsl:if>
             <xsl:apply-templates select="node() | @*"/>
         </xsl:copy>
@@ -479,9 +490,7 @@
         </xsl:copy>
         <xsl:if test="not(following-sibling::mei:encodingDesc)">
             <xsl:element name="encodingDesc" namespace="http://www.music-encoding.org/ns/mei">
-                <xsl:element name="appInfo" namespace="http://www.music-encoding.org/ns/mei">
-                    <xsl:call-template name="appInfo-insert-current-application"/>
-                </xsl:element>
+                <xsl:call-template name="encodingDesc-insert-appInfo"/>
             </xsl:element>
         </xsl:if>
     </xsl:template>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -498,36 +498,16 @@
         <xd:desc>Add a record of the conversion to revisionDesc</xd:desc>
     </xd:doc>
     <xsl:template name="revisionDesc-insert-change">
+        <!-- Add a record of the conversion to revisionDesc -->
         <change xmlns="http://www.music-encoding.org/ns/mei">
             <xsl:if test="count(mei:change[@n]) = count(mei:change)">
                 <xsl:attribute name="n" select="count(mei:change) + 1"/>
-            
-            <!-- Add a record of the conversion to revisionDesc -->
-            <change xmlns="http://www.music-encoding.org/ns/mei">
-                <xsl:if test="count(mei:change[@n]) = count(mei:change)">
-                    <xsl:attribute name="n" select="count(mei:change) + 1"/>
-                </xsl:if>
-                <xsl:attribute name="resp">
-                    <xsl:value-of select="concat('#', $progid)"/>
-                </xsl:attribute>
-                <changeDesc>
-                    <p><xsl:value-of select="'Converted to MEI version 5.0 using ' || $progname || ', version ' || $version"/></p>
-                </changeDesc>
-                <date>
-                    <xsl:attribute name="isodate">
-                        <xsl:value-of select="format-date(current-date(), '[Y]-[M02]-[D02]')"/>
-                    </xsl:attribute>
-                </date>
-            </change>
-            </xsl:if>
-            <xsl:if test="$verbose">
-                <xsl:message select="'Added change element to the encoding.'"/>
             </xsl:if>
             <xsl:attribute name="resp">
                 <xsl:value-of select="concat('#', $progid)"/>
             </xsl:attribute>
             <changeDesc>
-                <p><xsl:value-of select="'Converted to MEI version 5.0.0 using ' || $progname || ', version ' || $version"/></p>
+                <p><xsl:value-of select="'Converted to MEI version 5.0 using ' || $progname || ', version ' || $version"/></p>
             </changeDesc>
             <date>
                 <xsl:attribute name="isodate">

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -353,7 +353,7 @@
     </xsl:template>
     
     <xd:doc>
-        <xd:desc>Resolve changes in @meter.form, moving @meter.from="invis" to @meter.visible</xd:desc>
+        <xd:desc>Resolve changes in @meter.form, moving @meter.form="invis" to @meter.visible</xd:desc>
     </xd:doc>
     <xsl:template match="@meter.form">
         <xsl:choose>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -523,6 +523,17 @@
         </xsl:choose>
     </xsl:template>
     
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Removes @visible on mRest</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:mRest/@visible">
+        <xsl:if test="$verbose">
+            <xsl:message select="'Dropping @visible on mRest ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
+        </xsl:if>
+    </xsl:template>
+    
     <!-- ======================================================================= -->
     <!-- SELF-DOCUMENTATION TEMPLATES                                            -->
     <!-- ======================================================================= -->

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -152,6 +152,22 @@
     <!-- ======================================================================= -->
     
     <xd:doc>
+        <xd:desc>Insert @meiversion on root element if not present.</xd:desc>
+    </xd:doc>
+    <xsl:template match="/mei:*">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="not(@meiversion)">
+                <xsl:attribute name="meiversion" select="$meiversion"/>
+                <xsl:if test="$verbose">
+                    <xsl:message select="'Inserting @meiversion on ' || local-name(parent::mei:*) || ' with value: ' || $meiversion"/>
+                </xsl:if>
+            </xsl:if>
+            <xsl:apply-templates select="node() | @*"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xd:doc>
         <xd:desc>
             <xd:p>pgHead2 for subsequent pages is now encoded as pgHead with func="all", assuming another pgHead will use func="first"</xd:p>
         </xd:desc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -308,6 +308,17 @@
     
     <xd:doc>
         <xd:desc>
+            <xd:p>Removes @instr on mRest</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:mRest/@instr">
+        <xsl:if test="$verbose">
+            <xsl:message select="'Dropping @instr on mRest ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
+        </xsl:if>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
             <xd:p>Replace @key.sig with @keysig.</xd:p>
         </xd:desc>
     </xd:doc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -352,6 +352,30 @@
     </xsl:template>
     
     <xd:doc>
+        <xd:desc>
+            <xd:p>Replace @sig.showchange with @cancelaccid.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="@sig.showchange">
+        <xsl:variable name="value.old" select="."/>
+        <xsl:variable name="value.new">
+            <xsl:choose>
+                <xsl:when test="$value.old = 'false'">none</xsl:when>
+                <xsl:otherwise>before</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:attribute name="cancelaccid" select="$value.new"/>
+        <xsl:if test="$verbose">
+            <xsl:message>
+                <xsl:value-of select="'Changing @sig.showchange to @cancelaccid on ' || local-name(parent::mei:*) || ' ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id || '. '"/>
+                <xsl:text>Please note: converting value from </xsl:text>
+                <xsl:value-of select="$value.old"/><xsl:text> to </xsl:text><xsl:value-of select="$value.new"/><xsl:text>. </xsl:text>
+                <xsl:if test="$value.old = 'true'">There are several alternatives for encoding the style of MEI 4 @sig.showchange='true' in MEI 5.0 (before, after, before-bar), defaulting to 'before'.</xsl:if>
+            </xsl:message>
+        </xsl:if>
+    </xsl:template>
+    
+    <xd:doc>
         <xd:desc>Resolve changes in @meter.form, moving @meter.form="invis" to @meter.visible</xd:desc>
     </xd:doc>
     <xsl:template match="@meter.form">

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -321,7 +321,6 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="@keysig.show">
-        <!-- TODO : keysig.visible, same of staffDef -->
         <xsl:attribute name="keysig.visible" select="."/>
         <xsl:if test="$verbose">
             <xsl:message select="'Changing @keysig.show to @keysig.visible on ' || local-name(parent::mei:*) || ' ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -319,6 +319,17 @@
     
     <xd:doc>
         <xd:desc>
+            <xd:p>Removes @instr on rest</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:rest/@instr">
+        <xsl:if test="$verbose">
+            <xsl:message select="'Dropping @instr on rest ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
+        </xsl:if>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
             <xd:p>Replace @key.sig with @keysig.</xd:p>
         </xd:desc>
     </xd:doc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -413,6 +413,22 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
+    <xd:doc>
+        <xd:desc>Resolve changes in meterSig/@form, moving @form="invis" to @visible="false"</xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:meterSig/@form">
+        <xsl:choose>
+            <xsl:when test=". = 'invis'">
+                <xsl:attribute name="visible">false</xsl:attribute>
+                <xsl:if test="$verbose">
+                    <xsl:message select="'Changing @form with value `invis` to @visible with value `false` on meterSig ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
+                </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
     
     <xd:doc>
         <xd:desc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -413,6 +413,7 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
+    
     <xd:doc>
         <xd:desc>Resolve changes in meterSig/@form, moving @form="invis" to @visible="false"</xd:desc>
     </xd:doc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -255,6 +255,30 @@
     
     <xd:doc>
         <xd:desc>
+            <xd:p>Replace @keysig.showchange with @keysig.cancelaccid.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="@keysig.showchange">
+        <xsl:variable name="value.old" select="."/>
+        <xsl:variable name="value.new">
+            <xsl:choose>
+                <xsl:when test="$value.old = 'false'">none</xsl:when>
+                <xsl:otherwise>before</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:attribute name="keysig.cancelaccid" select="$value.new"/>
+        <xsl:if test="$verbose">
+            <xsl:message>
+                <xsl:value-of select="'Changing @keysig.showchange to @keysig.cancelaccid on ' || local-name(parent::mei:*) || ' ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
+                <xsl:text>. Please note: converting value from </xsl:text>
+                <xsl:value-of select="$value.old"/><xsl:text> to </xsl:text><xsl:value-of select="$value.new"/><xsl:text>. </xsl:text>
+                <xsl:if test="$value.old = 'true'">There are several alternatives for encoding the style of MEI 4 @keysig.showchange='true' in MEI 5.0 (before, after, before-bar), defaulting to 'before'.</xsl:if>
+            </xsl:message>
+        </xsl:if>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
             <xd:p>Resolve @text.dist</xd:p>
         </xd:desc>
     </xd:doc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -286,6 +286,28 @@
     
     <xd:doc>
         <xd:desc>
+            <xd:p>Removes @visible on mRest</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:mRest/@visible">
+        <xsl:if test="$verbose">
+            <xsl:message select="'Dropping @visible on mRest ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
+        </xsl:if>
+    </xsl:template>
+    
+   <xd:doc>
+        <xd:desc>
+            <xd:p>Removes @instr on mRest</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:mRest/@instr">
+        <xsl:if test="$verbose">
+            <xsl:message select="'Dropping @instr on mRest ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
+        </xsl:if>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
             <xd:p>Removes @instr on mSpace</xd:p>
         </xd:desc>
     </xd:doc>
@@ -303,17 +325,6 @@
     <xsl:template match="mei:multiRest/@instr">
         <xsl:if test="$verbose">
             <xsl:message select="'Dropping @instr on multiRest ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
-        </xsl:if>
-    </xsl:template>
-    
-    <xd:doc>
-        <xd:desc>
-            <xd:p>Removes @instr on mRest</xd:p>
-        </xd:desc>
-    </xd:doc>
-    <xsl:template match="mei:mRest/@instr">
-        <xsl:if test="$verbose">
-            <xsl:message select="'Dropping @instr on mRest ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
         </xsl:if>
     </xsl:template>
     
@@ -538,17 +549,6 @@
                 <xsl:next-match/>
             </xsl:otherwise>
         </xsl:choose>
-    </xsl:template>
-    
-    <xd:doc>
-        <xd:desc>
-            <xd:p>Removes @visible on mRest</xd:p>
-        </xd:desc>
-    </xd:doc>
-    <xsl:template match="mei:mRest/@visible">
-        <xsl:if test="$verbose">
-            <xsl:message select="'Dropping @visible on mRest ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
-        </xsl:if>
     </xsl:template>
     
     <!-- ======================================================================= -->

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -348,6 +348,30 @@
     
     <xd:doc>
         <xd:desc>
+            <xd:p>Decide whether to keep instrDef/@n or replace it with instrDef/@label, depending on its contents.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:instrDef/@n">
+        <xsl:choose>
+            <xsl:when test="matches(., '^[1-9]\d*$')">
+                <xsl:copy-of select="."/>
+            </xsl:when>
+            <xsl:when test="matches(., '^[\w_-]+$')">
+                <xsl:if test="$verbose">
+                    <xsl:message select="'Changing instrDef/@n to @label, because it contains non-numeric characters.'"/>
+                </xsl:if>
+                <xsl:attribute name="label" select="."/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message terminate="yes">The @n on instrDef seems to be invalid in the source file.
+                <xsl:value-of select="document-uri(root())"/>
+                </xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
             <xd:p>A value of "dblwhole" on @head.mod replaced with "fences".</xd:p>
         </xd:desc>
     </xd:doc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -233,6 +233,15 @@
     
     <xd:doc>
         <xd:desc>
+            <xd:p>Replace @key.sig with @keysig.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="@key.sig">
+        <xsl:attribute name="keysig" select="."/>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
             <xd:p>Replace @keysig.show with @keysig.visible.</xd:p>
         </xd:desc>
     </xd:doc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -424,21 +424,66 @@
     
     <xd:doc>
         <xd:desc>
-            <xd:p>Add info about the XSLT to the file</xd:p>
+            <xd:p>Insert mei:application with info about the XSLT to an exisiting mei:appInfo.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="mei:appInfo">
         <xsl:copy>
             <xsl:apply-templates select="node() | @*"/>
-            
-            <application xmlns="http://www.music-encoding.org/ns/mei">
-                <xsl:attribute name="version" select="'v' || replace($version, '&#32;', '_')"/>
-                <xsl:attribute name="xml:id" select="$progid"/>
-                
-                <name><xsl:value-of select="$progname"/></name>
-                <ptr target="{$gitUrl}"/>
-            </application>
+            <xsl:call-template name="appInfo-insert-current-application"/>
         </xsl:copy>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Create mei:application element with info about this XSLT.</xd:p>
+        </xd:desc>
+    </xd:doc>    
+    <xsl:template name="appInfo-insert-current-application">
+        <xsl:element name="application" namespace="http://www.music-encoding.org/ns/mei">
+            <xsl:attribute name="version" select="'v' || replace($version, '&#32;', '_')"/>
+            <xsl:attribute name="xml:id" select="$progid"/>
+            
+            <xsl:element name="name" namespace="http://www.music-encoding.org/ns/mei"><xsl:value-of select="$progname"/></xsl:element>
+            <xsl:element name="ptr" namespace="http://www.music-encoding.org/ns/mei">
+                <xsl:attribute name=" target" select="$gitUrl"/>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Copy mei:encodingDesc and, if not present, insert mei:appInfo as first child  with self-documentation.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:encodingDesc">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <xsl:if test="not(mei:appInfo)">
+                <xsl:element name="appInfo" namespace="http://www.music-encoding.org/ns/mei">
+                    <xsl:call-template name="appInfo-insert-current-application"/>
+                </xsl:element>
+            </xsl:if>
+            <xsl:apply-templates select="node() | @*"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Copy mei:fileDesc and, if not present, insert mei:encodingDesc/mei:appInfo after it with self-documentation.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:fileDesc">
+        <xsl:copy>
+            <xsl:apply-templates select="node() | @*"/>
+        </xsl:copy>
+        <xsl:if test="not(following-sibling::mei:encodingDesc)">
+            <xsl:element name="encodingDesc" namespace="http://www.music-encoding.org/ns/mei">
+                <xsl:element name="appInfo" namespace="http://www.music-encoding.org/ns/mei">
+                    <xsl:call-template name="appInfo-insert-current-application"/>
+                </xsl:element>
+            </xsl:element>
+        </xsl:if>
     </xsl:template>
     
     <xd:doc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -294,6 +294,23 @@
     </xsl:template>
     
     <xd:doc>
+        <xd:desc>Resolve changes in @meter.form, moving @meter.from="invis" to @meter.visible</xd:desc>
+    </xd:doc>
+    <xsl:template match="@meter.form">
+        <xsl:choose>
+            <xsl:when test=". = 'invis'">
+                <xsl:attribute name="meter.visible">false</xsl:attribute>
+                <xsl:if test="$verbose">
+                    <xsl:message>Changing @meter with value "invis" to @meter.visible with value "false"</xsl:message>
+                </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xd:doc>
         <xd:desc>
             <xd:p>Resolve @text.dist</xd:p>
         </xd:desc>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -519,6 +519,7 @@
                     </xsl:attribute>
                 </date>
             </change>
+            </xsl:if>
             <xsl:if test="$verbose">
                 <xsl:message select="'Added change element to the encoding.'"/>
             </xsl:if>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -414,27 +414,45 @@
     <xsl:template match="mei:revisionDesc">
         <xsl:copy>
             <xsl:apply-templates select="node() | @*"/>
-            
-            <!-- Add a record of the conversion to revisionDesc -->
-            <change xmlns="http://www.music-encoding.org/ns/mei">
-                <xsl:if test="count(mei:change[@n]) = count(mei:change)">
-                    <xsl:attribute name="n" select="count(mei:change) + 1"/>
-                </xsl:if>
-                <xsl:attribute name="resp">
-                    <xsl:value-of select="concat('#', $progid)"/>
-                </xsl:attribute>
-                <changeDesc>
-                    <p><xsl:value-of select="'Converted to MEI version 5.0.0 using ' || $progname || ', version ' || $version"/></p>
-                </changeDesc>
-                <date>
-                    <xsl:attribute name="isodate">
-                        <xsl:value-of select="format-date(current-date(), '[Y]-[M02]-[D02]')"/>
-                    </xsl:attribute>
-                </date>
-            </change>
-            <xsl:if test="$verbose">
-                <xsl:message select="'Added change element to the encoding.'"/>
+            <xsl:call-template name="revisionDesc-insert-change"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>Add a record of the conversion to revisionDesc</xd:desc>
+    </xd:doc>
+    <xsl:template name="revisionDesc-insert-change">
+        <change xmlns="http://www.music-encoding.org/ns/mei">
+            <xsl:if test="count(mei:change[@n]) = count(mei:change)">
+                <xsl:attribute name="n" select="count(mei:change) + 1"/>
             </xsl:if>
+            <xsl:attribute name="resp">
+                <xsl:value-of select="concat('#', $progid)"/>
+            </xsl:attribute>
+            <changeDesc>
+                <p><xsl:value-of select="'Converted to MEI version 5.0.0 using ' || $progname || ', version ' || $version"/></p>
+            </changeDesc>
+            <date>
+                <xsl:attribute name="isodate">
+                    <xsl:value-of select="format-date(current-date(), '[Y]-[M02]-[D02]')"/>
+                </xsl:attribute>
+            </date>
+        </change>
+        <xsl:if test="$verbose">
+            <xsl:message select="'Added change element to the encoding.'"/>
+        </xsl:if>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>Insert mei:revisionDesc if not present</xd:desc>
+    </xd:doc>
+    <xsl:template match="mei:meiHead[not(mei:revisionDesc)]">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <xsl:element name="revisionDesc" namespace="http://www.music-encoding.org/ns/mei">
+                <xsl:call-template name="revisionDesc-insert-change"/>
+            </xsl:element>
+            <xsl:message>Added revisionDesc to the encoding.</xsl:message>
         </xsl:copy>
     </xsl:template>
     

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -461,7 +461,7 @@
     </xsl:template>
     
     <xd:doc>
-        <xd:desc>Insert mei:revisionDesc if not present</xd:desc>
+        <xd:desc>Insert mei:revisionDesc if not present.</xd:desc>
     </xd:doc>
     <xsl:template match="mei:meiHead[not(mei:revisionDesc)]">
         <xsl:copy>

--- a/mei40To50/mei40To50.xsl
+++ b/mei40To50/mei40To50.xsl
@@ -343,8 +343,8 @@
         <xsl:attribute name="keysig.cancelaccid" select="$value.new"/>
         <xsl:if test="$verbose">
             <xsl:message>
-                <xsl:value-of select="'Changing @keysig.showchange to @keysig.cancelaccid on ' || local-name(parent::mei:*) || ' ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id"/>
-                <xsl:text>. Please note: converting value from </xsl:text>
+                <xsl:value-of select="'Changing @keysig.showchange to @keysig.cancelaccid on ' || local-name(parent::mei:*) || ' ' || ancestor-or-self::mei:*[@xml:id][1]/@xml:id || '. '"/>
+                <xsl:text>Please note: converting value from </xsl:text>
                 <xsl:value-of select="$value.old"/><xsl:text> to </xsl:text><xsl:value-of select="$value.new"/><xsl:text>. </xsl:text>
                 <xsl:if test="$value.old = 'true'">There are several alternatives for encoding the style of MEI 4 @keysig.showchange='true' in MEI 5.0 (before, after, before-bar), defaulting to 'before'.</xsl:if>
             </xsl:message>


### PR DESCRIPTION
This PR adds some changes that were introduced later or missed in the first place in #30 :

* Replace `@key.sig` with `@keysig`
* Replace `@keysig.showchange` with `@keysig.cancelaccid`
* Replace `instrDef/@n` with `@label` if contains non numerical content
* Replace `@meter.form="invis"` with `@meter.visible="false"`

And some improvements:
* Always insert xml-model processing instructions; depending on preexisting or submitted value 
* insert `@meiversion` on root element if not present
* insert self-documentation (`mei:application` and `mei:change`) even if `mei:encodingDesc` or `mei:appInfo`, resp. `mei:revisionDesc` are missing
